### PR TITLE
tests/server-test: fix the tests on usr-merged systems

### DIFF
--- a/tests/server-test.c
+++ b/tests/server-test.c
@@ -107,7 +107,8 @@ test_uccs_exec (void)
 	g_assert(server != NULL);
 	g_assert(g_strcmp0(server->name, "My Server") == 0);
 	g_assert(g_strcmp0(server->uri, "http://my.domain.com") == 0);
-	g_assert(g_strcmp0(UCCS_SERVER(server)->exec, "/bin/ls") == 0);
+	g_assert(g_strcmp0(UCCS_SERVER(server)->exec, "/bin/ls") == 0 ||
+			 g_strcmp0(UCCS_SERVER(server)->exec, "/usr/bin/ls") == 0);
 
 	g_object_unref(server);
 	g_key_file_unref(keyfile);


### PR DESCRIPTION
The testsuite is failing on Ubuntu builders as they operate with /bin a symlink to /usr/bin. As a result, depending on how you resolve it, `ls` can either be `/bin/ls` or `/usr/bin/ls`. Since Debian also seems to transition to such a setup, it might be wise to simply relax the tests.